### PR TITLE
fix(api): prefer @langchain/langgraph from project rather than CLI

### DIFF
--- a/libs/langgraph-api/src/cli/entrypoint.mts
+++ b/libs/langgraph-api/src/cli/entrypoint.mts
@@ -1,5 +1,3 @@
-import "../preload.mjs";
-
 import { asyncExitHook } from "exit-hook";
 import * as process from "node:process";
 import { startServer, StartServerSchema } from "../server.mjs";

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -44,7 +44,7 @@ For production use, please use LangGraph Cloud.
       "watch",
       "--clear-screen=false",
       "--import",
-      fileURLToPath(new URL(import.meta.resolve("../preload.mjs"))),
+      new URL(import.meta.resolve("../preload.mjs")).toString(),
       fileURLToPath(new URL(import.meta.resolve("./entrypoint.mjs"))),
       options.pid.toString(),
       JSON.stringify({

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -43,6 +43,8 @@ For production use, please use LangGraph Cloud.
       ),
       "watch",
       "--clear-screen=false",
+      "--import",
+      fileURLToPath(new URL(import.meta.resolve("../preload.mjs"))),
       fileURLToPath(new URL(import.meta.resolve("./entrypoint.mjs"))),
       options.pid.toString(),
       JSON.stringify({

--- a/libs/langgraph-api/src/graph/load.hooks.mjs
+++ b/libs/langgraph-api/src/graph/load.hooks.mjs
@@ -1,19 +1,22 @@
-// This hook is to ensure that @langchain/langgraph package
-// found in /api folder has precendence compared to user-provided package
-// found in /deps. Does not attempt to semver check for too old packages.
+// This module hook is used to ensure that @langchain/langgraph package
+// is imported from a consistent location.
+// Accepts `{ parentURL: string }` as argument when registering the hook.
 const OVERRIDE_RESOLVE = [
-  "@langchain/langgraph",
-  "@langchain/langgraph-checkpoint",
+  // Override `@langchain/langgraph` or `@langchain/langgraph/prebuilt`,
+  // but not `@langchain/langgraph-sdk`
+  new RegExp(`^@langchain\/langgraph(\/.+)?$`),
+  new RegExp(`^@langchain\/langgraph-checkpoint(\/.+)?$`),
 ];
 
-export async function resolve(specifier, context, nextResolve) {
-  if (OVERRIDE_RESOLVE.includes(specifier)) {
-    const parentURL = new URL("./load.mts", import.meta.url).toString();
-    return await nextResolve(specifier, {
-      ...context,
-      parentURL,
-    });
-  }
+let parentURL;
 
+export async function initialize(args) {
+  parentURL = args.parentURL;
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  if (OVERRIDE_RESOLVE.some((regex) => regex.test(specifier))) {
+    return await nextResolve(specifier, { ...context, parentURL });
+  }
   return nextResolve(specifier, context);
 }

--- a/libs/langgraph-api/src/graph/load.utils.mts
+++ b/libs/langgraph-api/src/graph/load.utils.mts
@@ -96,6 +96,7 @@ export async function runGraphSchemaWorker(spec: GraphSpec) {
   return await new Promise<Record<string, GraphSchema>>((resolve, reject) => {
     const worker = new Worker(
       fileURLToPath(new URL("./parser/parser.worker.mjs", import.meta.url)),
+      { argv: process.argv.slice(-1) },
     );
 
     // Set a timeout to reject if the worker takes too long

--- a/libs/langgraph-api/src/preload.mjs
+++ b/libs/langgraph-api/src/preload.mjs
@@ -5,10 +5,7 @@ import { join } from "node:path";
 // arguments passed to the entrypoint: [ppid, payload]
 // we only care about the payload, which contains the server definition
 const lastArg = process.argv.at(-1);
-const options = JSON.parse(lastArg || "{}") as {
-  graphs: Record<string, string>;
-  cwd: string;
-};
+const options = JSON.parse(lastArg || "{}");
 
 // find the first file, as `parentURL` needs to be a valid file URL
 // if no graph found, just assume a dummy default file, which should

--- a/libs/langgraph-api/src/preload.mjs
+++ b/libs/langgraph-api/src/preload.mjs
@@ -15,10 +15,10 @@ const firstGraphFile =
     .flatMap((i) => i.split(":").at(0))
     .at(0) || "index.mts";
 
-const parentURL = pathToFileURL(join(options.cwd, firstGraphFile)).toString();
-console.log("Parent URL", parentURL);
 // enforce API @langchain/langgraph resolution
 register("./graph/load.hooks.mjs", import.meta.url, {
   parentURL: "data:",
-  data: { parentURL },
+  data: {
+    parentURL: pathToFileURL(join(options.cwd, firstGraphFile)).toString(),
+  },
 });

--- a/libs/langgraph-api/src/preload.mjs
+++ b/libs/langgraph-api/src/preload.mjs
@@ -15,10 +15,10 @@ const firstGraphFile =
     .flatMap((i) => i.split(":").at(0))
     .at(0) || "index.mts";
 
+const parentURL = pathToFileURL(join(options.cwd, firstGraphFile)).toString();
+console.log("Parent URL", parentURL);
 // enforce API @langchain/langgraph resolution
 register("./graph/load.hooks.mjs", import.meta.url, {
   parentURL: "data:",
-  data: {
-    parentURL: pathToFileURL(join(options.cwd, firstGraphFile)).toString(),
-  },
+  data: { parentURL },
 });

--- a/libs/langgraph-api/src/preload.mts
+++ b/libs/langgraph-api/src/preload.mts
@@ -1,4 +1,27 @@
 import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+import { join } from "node:path";
 
-// enforce API @langchain/langgraph precedence
-register("./graph/load.hooks.mjs", import.meta.url);
+// arguments passed to the entrypoint: [ppid, payload]
+// we only care about the payload, which contains the server definition
+const lastArg = process.argv.at(-1);
+const options = JSON.parse(lastArg || "{}") as {
+  graphs: Record<string, string>;
+  cwd: string;
+};
+
+// find the first file, as `parentURL` needs to be a valid file URL
+// if no graph found, just assume a dummy default file, which should
+// be working fine as well.
+const firstGraphFile =
+  Object.values(options.graphs)
+    .flatMap((i) => i.split(":").at(0))
+    .at(0) || "index.mts";
+
+// enforce API @langchain/langgraph resolution
+register("./graph/load.hooks.mjs", import.meta.url, {
+  parentURL: "data:",
+  data: {
+    parentURL: pathToFileURL(join(options.cwd, firstGraphFile)).toString(),
+  },
+});


### PR DESCRIPTION
When `langgraphjs dev` is invoked via `npx`, peer deps are installed in the global npx cache.
