### PR TITLE
fix(api): make sure to persist after a while

### DIFF
--- a/libs/langgraph-api/src/cli/entrypoint.mts
+++ b/libs/langgraph-api/src/cli/entrypoint.mts
@@ -45,5 +45,5 @@ logger.info(`Server running at ${host}`);
 let queryParams = `?baseUrl=http://${options.host}:${options.port}`;
 if (organizationId) queryParams += `&organizationId=${organizationId}`;
 
-asyncExitHook(cleanup, { wait: 1000 });
+asyncExitHook(cleanup, { wait: 3_000 });
 sendToParent?.({ queryParams });

--- a/libs/langgraph-api/src/storage/ops.mts
+++ b/libs/langgraph-api/src/storage/ops.mts
@@ -916,7 +916,7 @@ export class Runs {
     attempt: number;
     signal: AbortSignal;
   }> {
-    yield* conn.withGenerator(async function* (STORE) {
+    yield* conn.withGenerator(async function* (STORE, options) {
       const now = new Date();
       const pendingRuns = Object.values(STORE.runs)
         .filter((run) => run.status === "pending" && run.created_at < now)
@@ -942,6 +942,7 @@ export class Runs {
         try {
           const signal = StreamManager.lock(runId);
 
+          options.schedulePersist();
           STORE.retry_counter[runId] ??= 0;
           STORE.retry_counter[runId] += 1;
 


### PR DESCRIPTION
Due to `.next()` being called in a loop, we would never automatically persist during idle time, thus sometimes the thread may disappear. Also bumped the wait limit for exit async hook.