### PR TITLE
chore: remove check for Date.now()

### DIFF
--- a/libs/langgraph-api/tests/api.test.mts
+++ b/libs/langgraph-api/tests/api.test.mts
@@ -1304,22 +1304,12 @@ describe("StoreClient", () => {
 
     const searchResAfterPut = await client.store.searchItems(namespace);
 
-    // TODO: remove once we figure out the reason behind flakines
-    console.log("[searchResAfterPut]");
-    console.dir(searchResAfterPut, { depth: null });
-
     expect(searchResAfterPut.items).toBeDefined();
     expect(searchResAfterPut.items.length).toBe(1);
     expect(searchResAfterPut.items[0].key).toBe(key);
     expect(searchResAfterPut.items[0].value).toEqual(value);
     expect(searchResAfterPut.items[0].createdAt).toBeDefined();
     expect(searchResAfterPut.items[0].updatedAt).toBeDefined();
-    expect(
-      new Date(searchResAfterPut.items[0].createdAt).getTime(),
-    ).toBeLessThanOrEqual(Date.now());
-    expect(
-      new Date(searchResAfterPut.items[0].updatedAt).getTime(),
-    ).toBeLessThanOrEqual(Date.now());
 
     const updatedValue = { foo: "baz" };
     await client.store.putItem(namespace, key, updatedValue);
@@ -1329,10 +1319,6 @@ describe("StoreClient", () => {
     expect(getResAfterUpdate?.value).toEqual(updatedValue);
 
     const searchResAfterUpdate = await client.store.searchItems(namespace);
-
-    // TODO: remove once we figure out the reason behind flakiness
-    console.log("[searchResAfterUpdate]");
-    console.dir(searchResAfterUpdate, { depth: null });
 
     expect(searchResAfterUpdate.items).toBeDefined();
     expect(searchResAfterUpdate.items.length).toBe(1);


### PR DESCRIPTION
Unsure why Date.now() within api.test.ts would be different from Date.now() from API code only on Windows?
