### PR TITLE
fix(api): do not rely on Response for `jsonExtra`

### DIFF
--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-api",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"

--- a/libs/langgraph-api/src/utils/hono.mts
+++ b/libs/langgraph-api/src/utils/hono.mts
@@ -4,10 +4,8 @@ import { stream } from "hono/streaming";
 import { StreamingApi } from "hono/utils/stream";
 
 export function jsonExtra<T>(c: Context, object: T) {
-  return new Response(serialiseAsDict(object), {
-    ...c.res,
-    headers: { ...c.res.headers, "Content-Type": "application/json" },
-  });
+  c.header("Content-Type", "application/json");
+  return c.body(serialiseAsDict(object));
 }
 
 export function waitKeepAlive(c: Context, promise: Promise<unknown>) {

--- a/libs/langgraph-cli/package.json
+++ b/libs/langgraph-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-cli",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"

--- a/libs/langgraph-ui/package.json
+++ b/libs/langgraph-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-ui",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"


### PR DESCRIPTION
Should resolve issues with https://github.com/nodejs/node/pull/53034 and https://github.com/langchain-ai/langgraph-studio/issues/247
